### PR TITLE
Add `--imports` flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ strip-ansi-escapes = { version = "0.1", optional = true }
 cli-table = { version = "0.4", optional = true }
 
 [patch.crates-io]
-checksec = { git = "https://github.com/etke/checksec.rs.git", features = ["elf", "pe", "color"], optional = true }
+checksec = { git = "https://github.com/etke/checksec.rs.git"} # Patch dependency does not support features
 
 [dev-dependencies]
 pprof = { version = "0.8", features = ["flamegraph"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xgadget"
-version = "0.7.0"
-authors = ["Tiemoko Ballo"]
+version = "0.8.0"
+authors = ["Tiemoko Ballo", "d3vco"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
@@ -21,7 +21,7 @@ include = [
 
 [dependencies]
 iced-x86 = "1"
-goblin = "0.4.3" # TODO: Cannot upgrade yet due to checksec dependency
+goblin = "0.5"
 rayon = "1"
 bitflags = "1"
 colored = "2"
@@ -31,14 +31,11 @@ clap = { version = "3", features = ["derive", "cargo"], optional = true }
 num_cpus = { version = "1", optional = true }
 regex = { version = "1", optional = true }
 term_size = { version = "0.3", optional = true }
-checksec = { version = "0.0.8", features = ["elf", "pe", "color"], optional = true }
+checksec = { version = "0.0.9", features = ["elf", "pe", "color"], optional = true }
 memmap = { version = "0.7", optional = true }
 num-format = { version = "0.4", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
 cli-table = { version = "0.4", optional = true }
-
-[patch.crates-io]
-checksec = { git = "https://github.com/etke/checksec.rs.git"} # Patch dependency does not support features
 
 [dev-dependencies]
 pprof = { version = "0.8", features = ["flamegraph"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 
 [dependencies]
 iced-x86 = "1"
-goblin = "0.2" # TODO: Cannot upgrade yet due to checksec dependency?
+goblin = "0.4.3" # TODO: Cannot upgrade yet due to checksec dependency
 rayon = "1"
 bitflags = "1"
 colored = "2"
@@ -36,6 +36,9 @@ memmap = { version = "0.7", optional = true }
 num-format = { version = "0.4", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
 cli-table = { version = "0.4", optional = true }
+
+[patch.crates-io]
+checksec = { git = "https://github.com/etke/checksec.rs.git", features = ["elf", "pe", "color"], optional = true }
 
 [dev-dependencies]
 pprof = { version = "0.8", features = ["flamegraph"] }

--- a/src/binary/binary.rs
+++ b/src/binary/binary.rs
@@ -385,13 +385,15 @@ pub fn get_all_param_regs(bins: &[Binary]) -> Vec<iced_x86::Register> {
     param_regs.into_iter().collect()
 }
 
-pub fn get_supported_macho<'a>(fat: &'a goblin::mach::MultiArch) -> Result<goblin::mach::MachO<'a>, Box<dyn Error>> {
+pub fn get_supported_macho<'a>(
+    fat: &'a goblin::mach::MultiArch
+) -> Result<goblin::mach::MachO<'a>, Box<dyn Error>> {
     let macho = fat
         .find(|arch| {
             (arch.as_ref().unwrap().cputype() == goblin::mach::constants::cputype::CPU_TYPE_X86_64)
             || (arch.as_ref().unwrap().cputype() == goblin::mach::constants::cputype::CPU_TYPE_I386)
-        }
-    ).ok_or("Failed to retrieve supported architecture from MultiArch Mach-O")??;
+    })
+    .ok_or("Failed to retrieve supported architecture from MultiArch Mach-O")??;
 
     Ok(macho)
 }

--- a/src/binary/binary.rs
+++ b/src/binary/binary.rs
@@ -213,14 +213,7 @@ impl Binary {
         let macho = match mach {
             goblin::mach::Mach::Binary(binary) => binary,
             goblin::mach::Mach::Fat(fat) => {
-                temp_macho = fat
-                    .find(|arch| {
-                        (arch.as_ref().unwrap().cputype()
-                            == goblin::mach::constants::cputype::CPU_TYPE_X86_64)
-                            || (arch.as_ref().unwrap().cputype()
-                                == goblin::mach::constants::cputype::CPU_TYPE_I386)
-                    })
-                    .ok_or("Failed to retrieve supported architecture from MultiArch Mach-O!")??;
+                temp_macho = get_supported_macho(fat)?;
                 &temp_macho
             }
         };
@@ -390,4 +383,15 @@ pub fn get_all_param_regs(bins: &[Binary]) -> Vec<iced_x86::Register> {
     }
 
     param_regs.into_iter().collect()
+}
+
+pub fn get_supported_macho<'a>(fat: &'a goblin::mach::MultiArch) -> Result<goblin::mach::MachO<'a>, Box<dyn Error>> {
+    let macho = fat
+        .find(|arch| {
+            (arch.as_ref().unwrap().cputype() == goblin::mach::constants::cputype::CPU_TYPE_X86_64)
+            || (arch.as_ref().unwrap().cputype() == goblin::mach::constants::cputype::CPU_TYPE_I386)
+        }
+    ).ok_or("Failed to retrieve supported architecture from MultiArch Mach-O")??;
+
+    Ok(macho)
 }

--- a/src/cli/checksec_fmt.rs
+++ b/src/cli/checksec_fmt.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use checksec::{
-    colorize_bool, elf::ElfCheckSecResults, macho::MachOCheckSecResults, pe::PECheckSecResults,
+    colorize_bool, elf, macho, pe,
 };
 use colored::Colorize;
 
@@ -21,7 +21,7 @@ fn remove_color(results: &str) -> String {
 
 // ELF results new type
 pub struct CustomElfCheckSecResults {
-    pub results: ElfCheckSecResults,
+    pub results: elf::CheckSecResults,
     pub no_color: bool,
 }
 
@@ -53,7 +53,7 @@ impl fmt::Display for CustomElfCheckSecResults {
 
 // PE results new type
 pub struct CustomPeCheckSecResults {
-    pub results: PECheckSecResults,
+    pub results: pe::CheckSecResults,
     pub no_color: bool,
 }
 
@@ -89,7 +89,7 @@ impl fmt::Display for CustomPeCheckSecResults {
 
 // Mach-O results new type
 pub struct CustomMachOCheckSecResults {
-    pub results: MachOCheckSecResults,
+    pub results: macho::CheckSecResults,
     pub no_color: bool,
 }
 

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -285,7 +285,17 @@ impl CLIOpts {
             let buf = fs::read(path).unwrap();
             match Object::parse(&buf).unwrap() {
                 Object::Elf(elf) => imports::dump_elf_imports(&elf, self.no_color),
-                _ => panic!("Only ELF imports currently supported!"),
+                Object::PE(pe) => imports::dump_pe_imports(&pe, self.no_color),
+                Object::Mach(mach) => match mach {
+                    goblin::mach::Mach::Binary(macho) => {
+                        imports::dump_macho_imports(&macho, self.no_color)
+                    },
+                    goblin::mach::Mach::Fat(fat) => {
+                        let macho = xgadget::binary::get_supported_macho(&fat).unwrap();
+                        imports::dump_macho_imports(&macho, self.no_color)
+                    },
+                },
+                _ => panic!("Only ELF, PE, and Mach-O binaries currently supported!"),
             }
         }
     }

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::fs;
 
-use checksec::{elf::ElfCheckSecResults, macho::MachOCheckSecResults, pe::PECheckSecResults};
+use checksec::{elf, macho, pe};
 use clap::Parser;
 use colored::Colorize;
 use goblin::Object;
@@ -222,7 +222,7 @@ impl CLIOpts {
                     println!(
                         "{}",
                         CustomElfCheckSecResults {
-                            results: ElfCheckSecResults::parse(&elf),
+                            results: elf::CheckSecResults::parse(&elf),
                             no_color: self.no_color,
                         }
                     );
@@ -233,7 +233,7 @@ impl CLIOpts {
                     println!(
                         "{}",
                         CustomPeCheckSecResults {
-                            results: PECheckSecResults::parse(&pe, &mm_buf),
+                            results: pe::CheckSecResults::parse(&pe, &mm_buf),
                             no_color: self.no_color,
                         }
                     );
@@ -243,7 +243,7 @@ impl CLIOpts {
                         println!(
                             "{}",
                             CustomMachOCheckSecResults {
-                                results: MachOCheckSecResults::parse(&macho),
+                                results: macho::CheckSecResults::parse(&macho),
                                 no_color: self.no_color,
                             }
                         );

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -289,11 +289,11 @@ impl CLIOpts {
                 Object::Mach(mach) => match mach {
                     goblin::mach::Mach::Binary(macho) => {
                         imports::dump_macho_imports(&macho, self.no_color)
-                    },
+                    }
                     goblin::mach::Mach::Fat(fat) => {
                         let macho = xgadget::binary::get_supported_macho(&fat).unwrap();
                         imports::dump_macho_imports(&macho, self.no_color)
-                    },
+                    }
                 },
                 _ => panic!("Only ELF, PE, and Mach-O binaries currently supported!"),
             }

--- a/src/cli/imports.rs
+++ b/src/cli/imports.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+pub fn elf_imports(elf: &goblin::elf::Elf) {
+    let mut vers_map = HashMap::new();
+
+    if let Some(verneed) = &elf.verneed {
+        for need_file in verneed.iter() {
+            for need_ver in need_file.iter() {
+                vers_map.insert(
+                    need_ver.vna_other,
+                    elf.dynstrtab.get_at(need_ver.vna_name).unwrap_or(""),
+                );
+            }
+        }
+    }
+
+    println!("   Num:    Value  Size Type    Bind   Vis      Ndx Name");
+
+    for (sym_idx, sym) in elf.dynsyms.into_iter().enumerate() {
+        if sym.is_import() {
+            print!("{:>6}: {:08} {:>5} ", sym_idx, sym.st_value, sym.st_size,);
+            print!("{:<7} ", get_symbol_type(&sym.st_type()));
+            print!("{:<6} ", get_symbol_binding(&sym.st_bind()));
+            print!("{:<8} ", get_symbol_visibility(&sym.st_visibility()));
+            print!("{:<3} ", get_symbol_index_type(&sym.st_shndx));
+            print!("{} ", elf.dynstrtab.get_at(sym.st_name).unwrap_or(""));
+                        println!(
+                            "{}",
+                            get_symbol_version_string(&elf, &vers_map, &sym_idx)
+                                .unwrap_or_else(|| "".to_string())
+                        );
+        }
+    }
+}
+
+fn get_symbol_type(sym_type: &u8) -> String {
+    match *sym_type {
+        goblin::elf::sym::STT_NOTYPE => "NOTYPE".to_string(),
+        goblin::elf::sym::STT_OBJECT => "OBJECT".to_string(),
+        goblin::elf::sym::STT_FUNC => "FUNC".to_string(),
+        goblin::elf::sym::STT_SECTION => "SECTION".to_string(),
+        goblin::elf::sym::STT_FILE => "FILE".to_string(),
+        goblin::elf::sym::STT_COMMON => "COMMON".to_string(),
+        goblin::elf::sym::STT_TLS => "TLS".to_string(),
+        _ => sym_type.to_string(),
+    }
+}
+
+fn get_symbol_binding(sym_bind: &u8) -> String {
+    match *sym_bind {
+        goblin::elf::sym::STB_LOCAL => "LOCAL".to_string(),
+        goblin::elf::sym::STB_GLOBAL => "GLOBAL".to_string(),
+        goblin::elf::sym::STB_WEAK => "WEAK".to_string(),
+        _ => sym_bind.to_string(),
+    }
+}
+
+fn get_symbol_visibility(sym_vis: &u8) -> String {
+    match *sym_vis {
+        goblin::elf::sym::STV_DEFAULT => "DEFAULT".to_string(),
+        goblin::elf::sym::STV_INTERNAL => "INTERNAL".to_string(),
+        goblin::elf::sym::STV_HIDDEN => "HIDDEN".to_string(),
+        goblin::elf::sym::STV_PROTECTED => "PROTECTED".to_string(),
+        _ => sym_vis.to_string(),
+    }
+}
+
+fn get_symbol_index_type(sym_type: &usize) -> String {
+    match *sym_type {
+        0 => "UND".to_string(),
+        0xfff1 => "ABS".to_string(),
+        0xfff2 => "COM".to_string(),
+        _ => sym_type.to_string(),
+    }
+}
+
+fn get_symbol_version_string(
+    elf: &goblin::elf::Elf,
+    vers_map: &HashMap<u16, &str>,
+    sym_idx: &usize,
+) -> Option<String> {
+    let vers_data = &elf.versym.as_ref()?.get_at(*sym_idx)?.vs_val;
+    let vers_string = vers_map.get(vers_data)?;
+
+    Some(format!("@ {} ({})", vers_string, vers_data))
+}

--- a/src/cli/imports.rs
+++ b/src/cli/imports.rs
@@ -1,86 +1,155 @@
-use std::collections::HashMap;
+use colored::Colorize;
+use std::fmt;
 
-pub fn elf_imports(elf: &goblin::elf::Elf) {
-    let mut vers_map = HashMap::new();
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct Symbol {
+    name: String,
+    source: String,
+    attrs: Vec<String>,
+    no_color: bool,
+}
 
-    if let Some(verneed) = &elf.verneed {
-        for need_file in verneed.iter() {
-            for need_ver in need_file.iter() {
-                vers_map.insert(
-                    need_ver.vna_other,
-                    elf.dynstrtab.get_at(need_ver.vna_name).unwrap_or(""),
-                );
-            }
+impl Symbol {
+    // Construction helper
+    fn priv_new() -> Symbol {
+        Symbol {
+            name: String::from("None"),
+            source: String::from("None"),
+            attrs: vec![],
+            no_color: false,
         }
     }
 
-    println!("   Num:    Value  Size Type    Bind   Vis      Ndx Name");
+    fn from_elf(
+        elf: &goblin::elf::Elf,
+        sym_idx: &usize,
+        sym: &goblin::elf::sym::Sym,
+        no_color: bool,
+    ) -> Symbol {
+        fn get_symbol_version_string(elf: &goblin::elf::Elf, sym_idx: &usize) -> Option<String> {
+            let vers_data = &elf.versym.as_ref()?.get_at(*sym_idx)?.vs_val;
 
+            let (need_str, vers_str) = if let Some(needed) = elf
+                .verneed
+                .as_ref()?
+                .iter()
+                .find(|v| v.iter().any(|f| f.vna_other == *vers_data))
+            {
+                if let Some(version) = needed.iter().find(|f| f.vna_other == *vers_data) {
+                    (
+                        elf.dynstrtab.get_at(needed.vn_file)?,
+                        elf.dynstrtab.get_at(version.vna_name)?,
+                    )
+                } else {
+                    return Some("".to_string());
+                }
+            } else {
+                return Some("".to_string());
+            };
+
+            Some(format!("{}, {} ({})", need_str, vers_str, vers_data))
+        }
+
+        let get_symbol_type = |val: u8| match val {
+            goblin::elf::sym::STT_NOTYPE => "NOTYPE".to_string(),
+            goblin::elf::sym::STT_OBJECT => "OBJECT".to_string(),
+            goblin::elf::sym::STT_FUNC => "FUNC".to_string(),
+            goblin::elf::sym::STT_SECTION => "SECTION".to_string(),
+            goblin::elf::sym::STT_FILE => "FILE".to_string(),
+            goblin::elf::sym::STT_COMMON => "COMMON".to_string(),
+            goblin::elf::sym::STT_TLS => "TLS".to_string(),
+            _ => val.to_string(),
+        };
+
+        let get_symbol_binding = |val: u8| match val {
+            goblin::elf::sym::STB_LOCAL => "LOCAL".to_string(),
+            goblin::elf::sym::STB_GLOBAL => "GLOBAL".to_string(),
+            goblin::elf::sym::STB_WEAK => "WEAK".to_string(),
+            _ => val.to_string(),
+        };
+
+        let get_symbol_visibility = |val: u8| match val {
+            goblin::elf::sym::STV_DEFAULT => "DEFAULT".to_string(),
+            goblin::elf::sym::STV_INTERNAL => "INTERNAL".to_string(),
+            goblin::elf::sym::STV_HIDDEN => "HIDDEN".to_string(),
+            goblin::elf::sym::STV_PROTECTED => "PROTECTED".to_string(),
+            _ => val.to_string(),
+        };
+
+        let get_symbol_index_type = |val: usize| match val {
+            0 => "UND".to_string(),
+            0xfff1 => "ABS".to_string(),
+            0xfff2 => "COM".to_string(),
+            _ => val.to_string(),
+        };
+
+        let mut symbol = Symbol::priv_new();
+
+        symbol.name = match elf.dynstrtab.get_at(sym.st_name) {
+            Some(s) => s.to_string(),
+            None => "".to_string(),
+        };
+
+        symbol.source = get_symbol_version_string(&elf, &sym_idx)
+            .unwrap_or_else(|| "Unable to parse source".to_string());
+
+        symbol.attrs = vec![
+            get_symbol_type(sym.st_type()),
+            get_symbol_binding(sym.st_bind()),
+            get_symbol_visibility(sym.st_visibility()),
+            get_symbol_index_type(sym.st_shndx),
+        ];
+
+        symbol.no_color = no_color;
+
+        symbol
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let color_punctuation = |s: &str| {
+            if self.no_color {
+                s.normal()
+            } else {
+                s.bright_magenta()
+            }
+        };
+
+        let single_quote = color_punctuation("'");
+        let colon = color_punctuation(":");
+
+        write!(
+            f,
+            "{}{}{}{} {} {}",
+            single_quote,
+            {
+                match self.no_color {
+                    true => format!("{}", self.name).normal(),
+                    false => format!("{}", self.name).yellow(),
+                }
+            },
+            single_quote,
+            colon,
+            {
+                match self.no_color {
+                    true => format!("{}", self.source).normal(),
+                    false => format!("{}", self.source).green(),
+                }
+            },
+            format!("{:?}", self.attrs).normal(),
+        )
+    }
+}
+
+pub fn dump_elf_imports(elf: &goblin::elf::Elf, no_color: bool) {
+    println!("Imported symbols:");
+    println!("  'name': library, version (version number) [type, binding, visibility, ndx]");
     for (sym_idx, sym) in elf.dynsyms.into_iter().enumerate() {
         if sym.is_import() {
-            print!("{:>6}: {:08} {:>5} ", sym_idx, sym.st_value, sym.st_size,);
-            print!("{:<7} ", get_symbol_type(&sym.st_type()));
-            print!("{:<6} ", get_symbol_binding(&sym.st_bind()));
-            print!("{:<8} ", get_symbol_visibility(&sym.st_visibility()));
-            print!("{:<3} ", get_symbol_index_type(&sym.st_shndx));
-            print!("{} ", elf.dynstrtab.get_at(sym.st_name).unwrap_or(""));
-                        println!(
-                            "{}",
-                            get_symbol_version_string(&elf, &vers_map, &sym_idx)
-                                .unwrap_or_else(|| "".to_string())
-                        );
+            let symbol = Symbol::from_elf(elf, &sym_idx, &sym, no_color);
+
+            println!("  {}", symbol);
         }
     }
-}
-
-fn get_symbol_type(sym_type: &u8) -> String {
-    match *sym_type {
-        goblin::elf::sym::STT_NOTYPE => "NOTYPE".to_string(),
-        goblin::elf::sym::STT_OBJECT => "OBJECT".to_string(),
-        goblin::elf::sym::STT_FUNC => "FUNC".to_string(),
-        goblin::elf::sym::STT_SECTION => "SECTION".to_string(),
-        goblin::elf::sym::STT_FILE => "FILE".to_string(),
-        goblin::elf::sym::STT_COMMON => "COMMON".to_string(),
-        goblin::elf::sym::STT_TLS => "TLS".to_string(),
-        _ => sym_type.to_string(),
-    }
-}
-
-fn get_symbol_binding(sym_bind: &u8) -> String {
-    match *sym_bind {
-        goblin::elf::sym::STB_LOCAL => "LOCAL".to_string(),
-        goblin::elf::sym::STB_GLOBAL => "GLOBAL".to_string(),
-        goblin::elf::sym::STB_WEAK => "WEAK".to_string(),
-        _ => sym_bind.to_string(),
-    }
-}
-
-fn get_symbol_visibility(sym_vis: &u8) -> String {
-    match *sym_vis {
-        goblin::elf::sym::STV_DEFAULT => "DEFAULT".to_string(),
-        goblin::elf::sym::STV_INTERNAL => "INTERNAL".to_string(),
-        goblin::elf::sym::STV_HIDDEN => "HIDDEN".to_string(),
-        goblin::elf::sym::STV_PROTECTED => "PROTECTED".to_string(),
-        _ => sym_vis.to_string(),
-    }
-}
-
-fn get_symbol_index_type(sym_type: &usize) -> String {
-    match *sym_type {
-        0 => "UND".to_string(),
-        0xfff1 => "ABS".to_string(),
-        0xfff2 => "COM".to_string(),
-        _ => sym_type.to_string(),
-    }
-}
-
-fn get_symbol_version_string(
-    elf: &goblin::elf::Elf,
-    vers_map: &HashMap<u16, &str>,
-    sym_idx: &usize,
-) -> Option<String> {
-    let vers_data = &elf.versym.as_ref()?.get_at(*sym_idx)?.vs_val;
-    let vers_string = vers_map.get(vers_data)?;
-
-    Some(format!("@ {} ({})", vers_string, vers_data))
 }

--- a/src/cli/imports.rs
+++ b/src/cli/imports.rs
@@ -5,100 +5,15 @@ use std::fmt;
 struct Import {
     name: String,
     source: String,
+    address: u64,
     attrs: Vec<String>,
     no_color: bool,
 }
 
 impl Import {
-    fn from_elf(
-        elf: &goblin::elf::Elf,
-        sym_idx: usize,
-        sym: &goblin::elf::sym::Sym,
-        no_color: bool,
-    ) -> Import {
-        fn get_symbol_version_string(elf: &goblin::elf::Elf, sym_idx: usize) -> Option<String> {
-            let versym = elf.versym.as_ref()?.get_at(sym_idx)?;
-
-            if versym.is_local() {
-                return Some("local".to_string());
-            } else if versym.is_global() {
-                return Some("global".to_string());
-            }
-
-            if let Some(needed) = elf
-                .verneed
-                .as_ref()?
-                .iter()
-                .find(|v| v.iter().any(|f| f.vna_other == versym.version()))
-            {
-                if let Some(version) = needed.iter().find(|f| f.vna_other == versym.version()) {
-                    let need_str = elf.dynstrtab.get_at(needed.vn_file)?;
-                    let vers_str = elf.dynstrtab.get_at(version.vna_name)?;
-                    return Some(format!("{}, {} ({})", need_str, vers_str, versym.version()));
-                }
-            }
-
-            None
-        }
-
-        fn get_got_plt_offset(elf: &goblin::elf::Elf, sym_idx: usize) -> Option<u64> {
-            let offset = if let Some(reloc) = elf.pltrelocs.iter().find(|r| r.r_sym == sym_idx) {
-                reloc.r_offset
-            } else {
-                return None;
-            };
-
-            Some(offset)
-        }
-
-        fn get_plt_offset(elf: &goblin::elf::Elf, sym_idx: usize) -> Option<u64> {
-            let reloc_idx = elf.pltrelocs.iter().position(|r| r.r_sym == sym_idx)?;
-
-            let mut offset = (reloc_idx as u64 + 1) * 16;
-
-            if let Some(plt) = &elf
-                .section_headers
-                .iter()
-                .find(|&s| elf.shdr_strtab.get_at(s.sh_name).unwrap().eq(".plt"))
-            {
-                offset += plt.sh_addr;
-            }
-
-            Some(offset)
-        }
-
-        let get_symbol_type = |val: u8| match val {
-            goblin::elf::sym::STT_NOTYPE => "NOTYPE".to_string(),
-            goblin::elf::sym::STT_OBJECT => "OBJECT".to_string(),
-            goblin::elf::sym::STT_FUNC => "FUNC".to_string(),
-            goblin::elf::sym::STT_SECTION => "SECTION".to_string(),
-            goblin::elf::sym::STT_FILE => "FILE".to_string(),
-            goblin::elf::sym::STT_COMMON => "COMMON".to_string(),
-            goblin::elf::sym::STT_TLS => "TLS".to_string(),
-            _ => val.to_string(),
-        };
-
-        let get_symbol_binding = |val: u8| match val {
-            goblin::elf::sym::STB_LOCAL => "LOCAL".to_string(),
-            goblin::elf::sym::STB_GLOBAL => "GLOBAL".to_string(),
-            goblin::elf::sym::STB_WEAK => "WEAK".to_string(),
-            _ => val.to_string(),
-        };
-
-        let get_symbol_visibility = |val: u8| match val {
-            goblin::elf::sym::STV_DEFAULT => "DEFAULT".to_string(),
-            goblin::elf::sym::STV_INTERNAL => "INTERNAL".to_string(),
-            goblin::elf::sym::STV_HIDDEN => "HIDDEN".to_string(),
-            goblin::elf::sym::STV_PROTECTED => "PROTECTED".to_string(),
-            _ => val.to_string(),
-        };
-
-        let get_symbol_index_type = |val: u32| match val {
-            goblin::elf::section_header::SHN_UNDEF => "UND".to_string(),
-            goblin::elf::section_header::SHN_ABS => "ABS".to_string(),
-            goblin::elf::section_header::SHN_COMMON => "COM".to_string(),
-            _ => val.to_string(),
-        };
+    fn from_elf(elf: &goblin::elf::Elf, reloc: &goblin::elf::Reloc, no_color: bool) -> Import {
+        let sym_idx = reloc.r_sym;
+        let sym = elf.dynsyms.get(sym_idx).unwrap(); //panic is unlikely, but could be handled better
 
         let mut imp = Import::default();
 
@@ -107,27 +22,30 @@ impl Import {
             None => "".to_string(),
         };
 
-        imp.source = get_symbol_version_string(&elf, sym_idx)
+        imp.source = get_elf_symbol_version_string(&elf, sym_idx)
             .unwrap_or_else(|| "Unable to parse source".to_string());
 
-        let got_plt_offset = match get_got_plt_offset(&elf, sym_idx) {
-            Some(offset) => format!("0x{:08x}", offset),
-            None => "n/a".to_string(),
-        };
+        imp.address = reloc.r_offset;
 
-        let plt_offset = match get_plt_offset(&elf, sym_idx) {
-            Some(offset) => format!("0x{:08x}", offset),
-            None => "n/a".to_string(),
+        let symbol_r_type = match elf.header.e_machine {
+            goblin::elf::header::EM_X86_64 => get_symbol_r_type_64(reloc.r_type),
+            goblin::elf::header::EM_386 => get_symbol_r_type_32(reloc.r_type),
+            _ => reloc.r_type.to_string(),
         };
 
         imp.attrs = vec![
-            got_plt_offset,
-            plt_offset,
-            get_symbol_type(sym.st_type()),
-            get_symbol_binding(sym.st_bind()),
-            get_symbol_visibility(sym.st_visibility()),
-            get_symbol_index_type(sym.st_shndx as u32),
+            symbol_r_type,
+            match get_plt_address(elf, &reloc) {
+                Some(a) => format!("{:#x}", a),
+                None => "".to_string(),
+            },
+            sym_idx.to_string(),
+            format!("{:#x}", sym.st_value),
         ];
+
+        if let Some(addend) = reloc.r_addend {
+            imp.attrs.push(addend.to_string())
+        }
 
         imp.no_color = no_color;
 
@@ -139,34 +57,33 @@ impl Import {
 
         imp.name = import.name.to_string();
         imp.source = import.dll.to_string();
+        imp.address = import.rva as u64;
 
-        let offset = format!("0x{:08x}", import.offset);
-        let rva = format!("0x{:08x}", import.rva);
+        let offset = format!("{:#x}", import.offset);
 
-        imp.attrs = vec![import.ordinal.to_string(), offset, rva];
+        imp.attrs = vec![import.ordinal.to_string(), offset];
 
         imp.no_color = no_color;
 
         imp
     }
 
-    fn from_macho(import: &goblin::mach::imports::Import, no_color: bool) -> Import {
+    fn from_macho(import: goblin::mach::imports::Import, no_color: bool) -> Import {
         let mut imp = Import::default();
 
         imp.name = import.name.to_string();
         imp.source = import.dylib.to_string();
+        imp.address = import.address;
 
-        let offset = format!("0x{:08x}", import.offset);
-        let address = format!("0x{:08x}", import.address);
-        let seq_offset = format!("0x{:08x}", import.start_of_sequence_offset);
+        let offset = format!("{:#x}", import.offset);
+        let seq_offset = format!("{:#x}", import.start_of_sequence_offset);
 
         imp.attrs = vec![
-            import.is_lazy.to_string(),
             offset,
-            address,
-            import.addend.to_string(),
-            import.is_weak.to_string(),
             seq_offset,
+            import.addend.to_string(),
+            import.is_lazy.to_string(),
+            import.is_weak.to_string(),
         ];
 
         imp.no_color = no_color;
@@ -190,7 +107,7 @@ impl fmt::Display for Import {
 
         write!(
             f,
-            "{}{}{}{}  {}  {}",
+            "{}{}{}{}  {}  {}  {}",
             single_quote,
             {
                 match self.no_color {
@@ -206,24 +123,52 @@ impl fmt::Display for Import {
                     false => format!("{}", self.source).green(),
                 }
             },
+            {
+                match self.no_color {
+                    true => format!("{:#x}", self.address).normal(),
+                    false => format!("{:#x}", self.address).red(),
+                }
+            },
             format!("{:?}", self.attrs).normal(),
         )
     }
 }
 
+// Dump Functions
+
 pub fn dump_elf_imports(elf: &goblin::elf::Elf, no_color: bool) {
-    println!("Imported symbols:");
-    println!("\t'name': library, version (version number) [got_plt_offset, plt_offset, type, binding, visibility, ndx]");
-    for (sym_idx, sym) in elf.dynsyms.into_iter().enumerate() {
-        if sym.is_import() {
-            println!("\t{}", Import::from_elf(elf, sym_idx, &sym, no_color));
+    println!("Procedural Linkage Table (PLT) symbols:");
+    print!("\tName: Source, Version  Address  [Reloc type, .plt address, Idx, Value");
+
+    if elf.dynamic.as_ref().unwrap().info.pltrel == goblin::elf::dynamic::DT_RELA {
+        println!(", Addend]");
+    } else {
+        println!("]");
+    }
+
+    for reloc in elf.pltrelocs.iter() {
+        println!("\t{}", Import::from_elf(elf, &reloc, no_color))
+    }
+
+    println!("\nOther dynamic symbols:");
+    print!("\tName: Source, Version  Address  [Reloc type, .plt address, Idx, Value");
+
+    if elf.dynamic.as_ref().unwrap().info.pltrel == goblin::elf::dynamic::DT_RELA {
+        println!(", Addend]");
+        for reloc in elf.dynrelas.iter() {
+            println!("\t{}", Import::from_elf(elf, &reloc, no_color))
+        }
+    } else {
+        println!("]");
+        for reloc in elf.dynrels.iter() {
+            println!("\t{}", Import::from_elf(elf, &reloc, no_color))
         }
     }
 }
 
 pub fn dump_pe_imports(pe: &goblin::pe::PE, no_color: bool) {
     println!("Imports:");
-    println!("\t'name': dll [ordinal, offset, rva]");
+    println!("\t'name': dll rva [ordinal, offset]");
     for import in pe.imports.iter().as_ref() {
         println!("\t{}", Import::from_pe(import, no_color));
     }
@@ -231,8 +176,140 @@ pub fn dump_pe_imports(pe: &goblin::pe::PE, no_color: bool) {
 
 pub fn dump_macho_imports(macho: &goblin::mach::MachO, no_color: bool) {
     println!("Imports:");
-    println!("\t'name': dylib [is lazily evaluated?, offset, address, addend, is weak?, start of sequence offset]");
+    println!("\t'name': dylib address [offset, start of sequence offset, addend, is lazily evaluated?, is weak?]");
     for import in macho.imports().expect("Error parsing imports") {
-        println!("\t{}", Import::from_macho(&import, no_color));
+        println!("\t{}", Import::from_macho(import, no_color));
+    }
+}
+
+// ELF Helper Functions
+
+fn get_elf_symbol_version_string(elf: &goblin::elf::Elf, sym_idx: usize) -> Option<String> {
+    let versym = elf.versym.as_ref()?.get_at(sym_idx)?;
+
+    if versym.is_local() {
+        return Some("local".to_string());
+    } else if versym.is_global() {
+        return Some("global".to_string());
+    } else if let Some(needed) = elf
+        .verneed
+        .as_ref()?
+        .iter()
+        .find(|v| v.iter().any(|f| f.vna_other == versym.version()))
+    {
+        if let Some(version) = needed.iter().find(|f| f.vna_other == versym.version()) {
+            let need_str = elf.dynstrtab.get_at(needed.vn_file)?;
+            let vers_str = elf.dynstrtab.get_at(version.vna_name)?;
+            return Some(format!("{}, {}", need_str, vers_str));
+        }
+    }
+
+    None
+}
+
+fn get_plt_address(elf: &goblin::elf::Elf, reloc: &goblin::elf::Reloc) -> Option<u64> {
+    // only handle JUMP_SLOT relocations
+    if reloc.r_type == goblin::elf::reloc::R_X86_64_JUMP_SLOT {
+        let reloc_idx = elf.pltrelocs.iter().position(|r| r == *reloc)?;
+        let plt_stub_len = 16;
+        let offset = (reloc_idx as u64 + 1) * plt_stub_len;
+
+        let plt_base = &elf
+            .section_headers
+            .iter()
+            .find(|s| elf.shdr_strtab.get_at(s.sh_name).unwrap().eq(".plt"))?
+            .sh_addr;
+
+        return Some(plt_base + offset);
+    }
+
+    None
+}
+
+fn get_symbol_r_type_64(sym_type: u32) -> String {
+    match sym_type {
+        goblin::elf::reloc::R_X86_64_NONE => "R_X86_64_NONE".to_string(),
+        goblin::elf::reloc::R_X86_64_64 => "R_X86_64_64".to_string(),
+        goblin::elf::reloc::R_X86_64_PC32 => "R_X86_64_PC32".to_string(),
+        goblin::elf::reloc::R_X86_64_GOT32 => "R_X86_64_GOT32".to_string(),
+        goblin::elf::reloc::R_X86_64_PLT32 => "R_X86_64_PLT32".to_string(),
+        goblin::elf::reloc::R_X86_64_COPY => "R_X86_64_COPY".to_string(),
+        goblin::elf::reloc::R_X86_64_GLOB_DAT => "R_X86_64_GLOB_DAT".to_string(),
+        goblin::elf::reloc::R_X86_64_JUMP_SLOT => "R_X86_64_JUMP_SLOT".to_string(),
+        goblin::elf::reloc::R_X86_64_RELATIVE => "R_X86_64_RELATIVE".to_string(),
+        goblin::elf::reloc::R_X86_64_GOTPCREL => "R_X86_64_GOTPCREL".to_string(),
+        goblin::elf::reloc::R_X86_64_32 => "R_X86_64_32".to_string(),
+        goblin::elf::reloc::R_X86_64_32S => "R_X86_64_32S".to_string(),
+        goblin::elf::reloc::R_X86_64_16 => "R_X86_64_16".to_string(),
+        goblin::elf::reloc::R_X86_64_PC16 => "R_X86_64_PC16".to_string(),
+        goblin::elf::reloc::R_X86_64_8 => "R_X86_64_8".to_string(),
+        goblin::elf::reloc::R_X86_64_PC8 => "R_X86_64_PC8".to_string(),
+        goblin::elf::reloc::R_X86_64_DTPMOD64 => "R_X86_64_DTPMOD64".to_string(),
+        goblin::elf::reloc::R_X86_64_DTPOFF64 => "R_X86_64_DTPOFF64".to_string(),
+        goblin::elf::reloc::R_X86_64_TPOFF64 => "R_X86_64_TPOFF64".to_string(),
+        goblin::elf::reloc::R_X86_64_TLSGD => "R_X86_64_TLSGD".to_string(),
+        goblin::elf::reloc::R_X86_64_TLSLD => "R_X86_64_TLSLD".to_string(),
+        goblin::elf::reloc::R_X86_64_DTPOFF32 => "R_X86_64_DTPOFF32".to_string(),
+        goblin::elf::reloc::R_X86_64_GOTTPOFF => "R_X86_64_GOTTPOFF".to_string(),
+        goblin::elf::reloc::R_X86_64_TPOFF32 => "R_X86_64_TPOFF32".to_string(),
+        goblin::elf::reloc::R_X86_64_PC64 => "R_X86_64_PC64".to_string(),
+        goblin::elf::reloc::R_X86_64_GOTOFF64 => "R_X86_64_GOTOFF64".to_string(),
+        goblin::elf::reloc::R_X86_64_GOTPC32 => "R_X86_64_GOTPC32".to_string(),
+        goblin::elf::reloc::R_X86_64_SIZE32 => "R_X86_64_SIZE32".to_string(),
+        goblin::elf::reloc::R_X86_64_SIZE64 => "R_X86_64_SIZE64".to_string(),
+        goblin::elf::reloc::R_X86_64_GOTPC32_TLSDESC => "R_X86_64_GOTPC32_TLSDESC".to_string(),
+        goblin::elf::reloc::R_X86_64_TLSDESC_CALL => "R_X86_64_TLSDESC_CALL".to_string(),
+        goblin::elf::reloc::R_X86_64_TLSDESC => "R_X86_64_TLSDESC".to_string(),
+        goblin::elf::reloc::R_X86_64_IRELATIVE => "R_X86_64_IRELATIVE".to_string(),
+        _ => sym_type.to_string(),
+    }
+}
+
+fn get_symbol_r_type_32(sym_type: u32) -> String {
+    match sym_type {
+        goblin::elf::reloc::R_386_8 => "R_386_8".to_string(),
+        goblin::elf::reloc::R_386_16 => "R_386_16".to_string(),
+        goblin::elf::reloc::R_386_32 => "R_386_32".to_string(),
+        goblin::elf::reloc::R_386_32PLT => "R_386_32PLT".to_string(),
+        goblin::elf::reloc::R_386_COPY => "R_386_COPY".to_string(),
+        goblin::elf::reloc::R_386_GLOB_DAT => "R_386_GLOB_DAT".to_string(),
+        goblin::elf::reloc::R_386_GOT32 => "R_386_GOT32".to_string(),
+        goblin::elf::reloc::R_386_GOT32X => "R_386_GOT32X".to_string(),
+        goblin::elf::reloc::R_386_GOTOFF => "R_386_GOTOFF".to_string(),
+        goblin::elf::reloc::R_386_GOTPC => "R_386_GOTPC".to_string(),
+        goblin::elf::reloc::R_386_IRELATIVE => "R_386_IRELATIVE".to_string(),
+        goblin::elf::reloc::R_386_JMP_SLOT => "R_386_JMP_SLOT".to_string(),
+        goblin::elf::reloc::R_386_NONE => "R_386_NONE".to_string(),
+        goblin::elf::reloc::R_386_NUM => "R_386_NUM".to_string(),
+        goblin::elf::reloc::R_386_PC8 => "R_386_PC8".to_string(),
+        goblin::elf::reloc::R_386_PC16 => "R_386_PC16".to_string(),
+        goblin::elf::reloc::R_386_PC32 => "R_386_PC32".to_string(),
+        goblin::elf::reloc::R_386_PLT32 => "R_386_PLT32".to_string(),
+        goblin::elf::reloc::R_386_RELATIVE => "R_386_RELATIVE".to_string(),
+        goblin::elf::reloc::R_386_SIZE32 => "R_386_SIZE32".to_string(),
+        goblin::elf::reloc::R_386_TLS_DESC => "R_386_TLS_DESC".to_string(),
+        goblin::elf::reloc::R_386_TLS_DESC_CALL => "R_386_TLS_DESC_CALL".to_string(),
+        goblin::elf::reloc::R_386_TLS_DTPMOD32 => "R_386_TLS_DTPMOD32".to_string(),
+        goblin::elf::reloc::R_386_TLS_DTPOFF32 => "R_386_TLS_DTPOFF32".to_string(),
+        goblin::elf::reloc::R_386_TLS_GD => "R_386_TLS_GD".to_string(),
+        goblin::elf::reloc::R_386_TLS_GD_32 => "R_386_TLS_GD_32".to_string(),
+        goblin::elf::reloc::R_386_TLS_GD_CALL => "R_386_TLS_GD_CALL".to_string(),
+        goblin::elf::reloc::R_386_TLS_GD_POP => "R_386_TLS_GD_POP".to_string(),
+        goblin::elf::reloc::R_386_TLS_GD_PUSH => "R_386_TLS_GD_PUSH".to_string(),
+        goblin::elf::reloc::R_386_TLS_GOTDESC => "R_386_TLS_GOTDESC".to_string(),
+        goblin::elf::reloc::R_386_TLS_GOTIE => "R_386_TLS_GOTIE".to_string(),
+        goblin::elf::reloc::R_386_TLS_IE => "R_386_TLS_IE".to_string(),
+        goblin::elf::reloc::R_386_TLS_IE_32 => "R_386_TLS_IE_32".to_string(),
+        goblin::elf::reloc::R_386_TLS_LDM => "R_386_TLS_LDM".to_string(),
+        goblin::elf::reloc::R_386_TLS_LDM_32 => "R_386_TLS_LDM_32".to_string(),
+        goblin::elf::reloc::R_386_TLS_LDM_CALL => "R_386_TLS_LDM_CALL".to_string(),
+        goblin::elf::reloc::R_386_TLS_LDM_POP => "R_386_TLS_LDM_POP".to_string(),
+        goblin::elf::reloc::R_386_TLS_LDM_PUSH => "R_386_TLS_LDM_PUSH".to_string(),
+        goblin::elf::reloc::R_386_TLS_LDO_32 => "R_386_TLS_LDO_32".to_string(),
+        goblin::elf::reloc::R_386_TLS_LE => "R_386_TLS_LE".to_string(),
+        goblin::elf::reloc::R_386_TLS_LE_32 => "R_386_TLS_LE_32".to_string(),
+        goblin::elf::reloc::R_386_TLS_TPOFF => "R_386_TLS_TPOFF".to_string(),
+        goblin::elf::reloc::R_386_TLS_TPOFF32 => "R_386_TLS_TPOFF32".to_string(),
+        _ => sym_type.to_string(),
     }
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -14,6 +14,8 @@ use cli::CLIOpts;
 
 mod checksec_fmt;
 
+mod imports;
+
 #[macro_use]
 extern crate lazy_static;
 
@@ -27,6 +29,13 @@ fn main() {
 
     if cli.check_sec {
         cli.run_checksec();
+        std::process::exit(0);
+    }
+
+    // Imports requested -----------------------------------------------------------------------------------------------
+
+    if cli.imports {
+        cli.run_imports();
         std::process::exit(0);
     }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -31,14 +31,6 @@ fn main() {
         cli.run_checksec();
         std::process::exit(0);
     }
-
-    // Imports requested -----------------------------------------------------------------------------------------------
-
-    if cli.imports {
-        cli.run_imports();
-        std::process::exit(0);
-    }
-
     // Process 1+ files ------------------------------------------------------------------------------------------------
 
     // File paths -> Binaries
@@ -58,6 +50,15 @@ fn main() {
             binary
         })
         .collect();
+
+    // Imports requested -----------------------------------------------------------------------------------------------
+
+    if cli.imports {
+        cli.run_imports(&bins);
+        std::process::exit(0);
+    }
+
+    // Print targets ____-----------------------------------------------------------------------------------------------
 
     for (i, bin) in bins.iter().enumerate() {
         println!(


### PR DESCRIPTION
- Resolves issue #6
- New flag `--imports`
- Bumps `goblin` to v0.4.3
- Uses `[patch]` to pull in the GitHub-hosted `checksec` for compatibility with `goblin` v0.4.3
- Refactors handling of Multi-Arch Mach-O binaries